### PR TITLE
meson.build: Fix sideeffects of subplugin install fix

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -37,12 +37,12 @@ override_dh_auto_configure:
 ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Denable-edgetpu=true -Denable-openvino=true -Dgrpc-support=disabled \
-	-Denable-tizen=false -Denable-test=true -Dinstall-test=true ${BUILDDIR}
+	-Denable-tizen=false -Denable-test=true -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer ${BUILDDIR}
 else
 	# Debian has less packages ready.
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Denable-edgetpu=false -Denable-openvino=false -Dgrpc-support=disabled -Dmqtt-support=enabled \
-	-Denable-tizen=false -Denable-test=true -Dinstall-test=true ${BUILDDIR}
+	-Denable-tizen=false -Denable-test=true -Dinstall-test=true -Dsubplugindir=/usr/lib/nnstreamer ${BUILDDIR}
 endif
 
 override_dh_auto_build:

--- a/meson.build
+++ b/meson.build
@@ -86,7 +86,6 @@ endforeach
 gst_api_verision = '1.0'
 
 # Set install path
-nnstreamer_prefix = get_option('prefix')
 nnstreamer_libdir = join_paths(nnstreamer_prefix, get_option('libdir'))
 nnstreamer_bindir = join_paths(nnstreamer_prefix, get_option('bindir'))
 nnstreamer_includedir = join_paths(nnstreamer_prefix, get_option('includedir'))
@@ -97,7 +96,12 @@ nnstreamer_inidir = join_paths(nnstreamer_prefix, get_option('sysconfdir'))
 plugins_install_dir = join_paths(nnstreamer_libdir, 'gstreamer-' + gst_api_verision)
 
 # nnstreamer sub-plugins path
-subplugin_install_prefix = join_paths(nnstreamer_prefix, get_option('libdir'), 'nnstreamer')
+nnstreamer_prefix = get_option('prefix')
+if get_option('subplugindir') == ''
+  subplugin_install_prefix = join_paths(nnstreamer_prefix, get_option('libdir'), 'nnstreamer')
+else
+  subplugin_install_prefix = get_option('subplugindir')
+endif
 filter_subplugin_install_dir = join_paths(subplugin_install_prefix, 'filters')
 decoder_subplugin_install_dir = join_paths(subplugin_install_prefix, 'decoders')
 customfilter_install_dir = join_paths(subplugin_install_prefix, 'customfilters')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -50,3 +50,6 @@ option('trix-engine-alias', type: 'string', value: 'srnpu', description: 'The al
 # Utilities
 option('enable-nnstreamer-check', type: 'boolean', value: true)
 option('enable-pbtxt-converter', type: 'boolean', value: true)
+
+# Install Paths
+option('subplugindir', type: 'string', value: '')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -781,7 +781,7 @@ CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-Wp,-D_FORTIFY_SOURCE=[1-9]||g"`
 mkdir -p build
 
 meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir=%{_lib} \
-	--bindir=%{nnstbindir} --includedir=include \
+	--bindir=%{nnstbindir} --includedir=include -Dsubplugindir=%{prefix}/%{_lib}/nnstreamer \
 	%{enable_tizen} %{element_restriction} %{fw_priority} -Denable-env-var=false -Denable-symbolic-link=false \
 	%{enable_tf_lite} %{enable_tf2_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python3} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_openvino} %{enable_armnn} %{enable_edgetpu}  %{enable_vivante} %{enable_flatbuf} \


### PR DESCRIPTION
The PR #3554 breaks conventional non-multilib builds of x64/aarch64
systems (Tizen/Ubuntu). This fixes this side-effect.

Todo: fix Yocto build afterwards.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
